### PR TITLE
feat: add pushduck as S3-native upload alternative to UploadThing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ AUTH_GITHUB_SECRET="..."
 UPLOADTHING_TOKEN="..."
 UPLOADTHING_SECRET_KEY="sk_live_..."
 
+# S3 file uploads via pushduck (alternative to UploadThing)
+# Supports AWS S3, Cloudflare R2, DigitalOcean Spaces, MinIO
+# https://github.com/abhay-ramesh/pushduck
+AWS_S3_ACCESS_KEY_ID=
+AWS_S3_SECRET_ACCESS_KEY=
+AWS_S3_REGION=us-east-1
+AWS_S3_BUCKET_NAME=
+
 # ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
 # ―― PAYMENTS ――――――――――――――――――――――――――――――
 # ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
+    "pushduck": "^0.4.0",
     "uploadthing": "^7.6.0",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,42 @@
+import { headers } from "next/headers";
+import { createUploadConfig } from "pushduck/server";
+
+import { auth } from "~/lib/auth";
+
+const { s3 } = createUploadConfig()
+  .provider("aws", {
+    accessKeyId: process.env.AWS_S3_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_S3_SECRET_ACCESS_KEY!,
+    region: process.env.AWS_S3_REGION!,
+    bucket: process.env.AWS_S3_BUCKET_NAME!,
+  })
+  .paths({
+    prefix: "uploads",
+    generateKey: (file, metadata) => {
+      const userId = (metadata as { userId?: string }).userId ?? "anonymous";
+      return `${userId}/${Date.now()}/${file.name}`;
+    },
+  })
+  .build();
+
+const uploadRouter = s3.createRouter({
+  imageUploader: s3
+    .image()
+    .maxFileSize("4MB")
+    .middleware(async () => {
+      const session = await auth.api.getSession({ headers: await headers() });
+      if (!session?.user?.id) throw new Error("Unauthorized");
+      return { userId: session.user.id };
+    }),
+  videoUploader: s3
+    .file()
+    .maxFileSize("64MB")
+    .middleware(async () => {
+      const session = await auth.api.getSession({ headers: await headers() });
+      if (!session?.user?.id) throw new Error("Unauthorized");
+      return { userId: session.user.id };
+    }),
+});
+
+export type AppUploadRouter = typeof uploadRouter;
+export const { GET, POST } = uploadRouter.handlers;

--- a/src/ui/components/pushduck-upload.tsx
+++ b/src/ui/components/pushduck-upload.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useRef } from "react";
+import { createUploadClient } from "pushduck/client";
+
+import type { AppUploadRouter } from "~/app/api/upload/route";
+
+const upload = createUploadClient<AppUploadRouter>({
+  endpoint: "/api/upload",
+});
+
+export function ImageUploader() {
+  const { uploadFiles, files, isUploading, reset } = upload.imageUploader();
+  const ref = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => ref.current?.click()}
+        onKeyDown={(e) => e.key === "Enter" && ref.current?.click()}
+        className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-border p-8 text-center transition-colors hover:border-primary"
+      >
+        <input
+          ref={ref}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          disabled={isUploading}
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? []);
+            if (files.length) uploadFiles(files);
+          }}
+        />
+        <p className="text-sm text-muted-foreground">
+          {isUploading ? "Uploading…" : "Click to upload images (max 4 MB each)"}
+        </p>
+      </div>
+
+      {files.length > 0 && (
+        <ul className="space-y-2">
+          {files.map((file) => (
+            <li
+              key={file.id}
+              className="flex items-center gap-3 rounded-md border border-border p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{file.name}</p>
+                {file.status === "uploading" && (
+                  <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-primary transition-all"
+                      style={{ width: `${file.progress}%` }}
+                    />
+                  </div>
+                )}
+                {file.status === "success" && file.url && (
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-0.5 block truncate text-xs text-primary hover:underline"
+                  >
+                    {file.url}
+                  </a>
+                )}
+                {file.status === "error" && (
+                  <p className="mt-0.5 text-xs text-destructive">
+                    {file.error ?? "Upload failed"}
+                  </p>
+                )}
+              </div>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {file.status === "uploading" ? `${file.progress}%` : file.status}
+              </span>
+            </li>
+          ))}
+          <button
+            type="button"
+            onClick={reset}
+            className="text-xs text-muted-foreground underline hover:text-foreground"
+          >
+            Clear
+          </button>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function VideoUploader() {
+  const { uploadFiles, files, isUploading, reset } = upload.videoUploader();
+  const ref = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => ref.current?.click()}
+        onKeyDown={(e) => e.key === "Enter" && ref.current?.click()}
+        className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-border p-8 text-center transition-colors hover:border-primary"
+      >
+        <input
+          ref={ref}
+          type="file"
+          accept="video/*"
+          multiple
+          className="hidden"
+          disabled={isUploading}
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? []);
+            if (files.length) uploadFiles(files);
+          }}
+        />
+        <p className="text-sm text-muted-foreground">
+          {isUploading ? "Uploading…" : "Click to upload videos (max 64 MB each)"}
+        </p>
+      </div>
+
+      {files.length > 0 && (
+        <ul className="space-y-2">
+          {files.map((file) => (
+            <li key={file.id} className="flex items-center gap-3 rounded-md border border-border p-3">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{file.name}</p>
+                {file.status === "uploading" && (
+                  <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                    <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${file.progress}%` }} />
+                  </div>
+                )}
+                {file.status === "success" && file.url && (
+                  <a href={file.url} target="_blank" rel="noreferrer" className="mt-0.5 block truncate text-xs text-primary hover:underline">{file.url}</a>
+                )}
+                {file.status === "error" && (
+                  <p className="mt-0.5 text-xs text-destructive">{file.error ?? "Upload failed"}</p>
+                )}
+              </div>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {file.status === "uploading" ? `${file.progress}%` : file.status}
+              </span>
+            </li>
+          ))}
+          <button type="button" onClick={reset} className="text-xs text-muted-foreground underline hover:text-foreground">Clear</button>
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds [pushduck](https://github.com/abhay-ramesh/pushduck) as a **parallel, opt-in upload alternative** to the existing UploadThing integration. UploadThing is completely unchanged — both systems coexist and users can choose either.

## What changed

**New files:**
- `src/app/api/upload/route.ts` — pushduck API route at `/api/upload`
- `src/ui/components/pushduck-upload.tsx` — drop-in `<ImageUploader />` and `<VideoUploader />` React components

**Modified files:**
- `.env.example` — adds `AWS_S3_*` vars section under UPLOADS
- `package.json` — adds `"pushduck": "^0.4.0"` dependency

## Why pushduck

| | UploadThing | pushduck |
|---|---|---|
| Storage | UploadThing-managed CDN | **Your own** S3 / R2 / Spaces / MinIO |
| Bandwidth cost | Included in plan | Files go browser → S3 directly (presigned URLs) — zero server bandwidth |
| Vendor lock-in | Yes | None |
| Route names | `imageUploader`, `videoUploader` | Same — `imageUploader`, `videoUploader` |

## Key design decisions

- **Presigned URL pattern** — the server only signs the upload; bytes travel directly from the browser to S3. No server bandwidth consumed.
- **Same route slug names** as UploadThing (`imageUploader`, `videoUploader`) so swapping is a one-line import change.
- **Auth parity** — middleware uses `auth.api.getSession()` identically to `core.ts`, so session handling is consistent.
- **File limits match** — 4 MB for images, 64 MB for videos, matching the existing UploadThing config.
- **Provider flexibility** — the `AWS_S3_*` vars work with any S3-compatible provider (Cloudflare R2, DigitalOcean Spaces, MinIO) by adjusting the endpoint.

## Required env vars (optional — only if using pushduck)

```env
AWS_S3_ACCESS_KEY_ID=
AWS_S3_SECRET_ACCESS_KEY=
AWS_S3_REGION=us-east-1
AWS_S3_BUCKET_NAME=
```

## Test plan

- [ ] UploadThing still works at `/api/uploadthing` (nothing changed)
- [ ] `<ImageUploader />` from `~/ui/components/pushduck-upload` renders and accepts image files
- [ ] `<VideoUploader />` from `~/ui/components/pushduck-upload` renders and accepts video files
- [ ] Unauthenticated upload attempt returns 401
- [ ] Authenticated upload produces a presigned URL and file lands in the configured S3 bucket
- [ ] Progress bar updates during upload, success URL displayed after completion

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)